### PR TITLE
hdlc: add universal hdlc_send_pkt() function for reuse

### DIFF
--- a/dispatcher.cpp
+++ b/dispatcher.cpp
@@ -70,9 +70,8 @@ DigitalOut led1(LED1);
 Mail<msg_t, HDLC_MAILBOX_SIZE> dispatcher_mailbox;
 Thread dispatcher; 
 static std::map <char, Mail<msg_t, HDLC_MAILBOX_SIZE>*> mailbox_list;
-static int registered_thr_cnt=0;
 Mutex thread_cnt_mtx;
-static int thread_cnt=0;
+static int thread_cnt = 0;
 
 int register_thread(Mail<msg_t, HDLC_MAILBOX_SIZE> *arg)
 {
@@ -92,11 +91,9 @@ void _dispatcher(void)
 
     hdlc_mailbox_ptr = get_hdlc_mailbox();
     msg_t *msg, *msg2;
-    char frame_no = 0;
-    char send_data[HDLC_MAX_PKT_SIZE];
     char recv_data[HDLC_MAX_PKT_SIZE];
 
-    hdlc_buf_t *buf;
+    hdlc_pkt_t *pkt;
     PRINTF("In dispatcher");
 
     msg = hdlc_mailbox_ptr->alloc();
@@ -129,8 +126,8 @@ void _dispatcher(void)
             switch (msg->type)
             {
                 case HDLC_PKT_RDY:
-                    buf = (hdlc_buf_t *)msg->content.ptr;   
-                    memcpy(recv_data, buf->data, buf->length);
+                    pkt = (hdlc_pkt_t *)msg->content.ptr;   
+                    memcpy(recv_data, pkt->data, pkt->length);
                     // PRINTF("dispatcher: received pkt %d; thread %d\n", recv_data[0],recv_data[1]);
 
                     if(recv_data[1]>0)
@@ -154,7 +151,7 @@ void _dispatcher(void)
                         PRINTF("dispatcher1: received pkt %d; thread %d\n", recv_data[0],recv_data[1]);
 
                         dispatcher_mailbox.free(msg);
-                        hdlc_pkt_release(buf);
+                        hdlc_pkt_release(pkt);
                     }
                     break;
                 default:
@@ -171,11 +168,11 @@ void _dispatcher(void)
     /* should be never reached */
     // return 0;
 }
+
 Mail<msg_t, HDLC_MAILBOX_SIZE>* get_dispacther_mailbox()
 {
     return &dispatcher_mailbox;
 }
-
 
 Mail<msg_t, HDLC_MAILBOX_SIZE>* dispacher_init() 
 {

--- a/hdlc.cpp
+++ b/hdlc.cpp
@@ -77,31 +77,28 @@ static Mail<msg_t, HDLC_MAILBOX_SIZE> *dispatcher_mailbox_ptr;
 static Mail<msg_t, HDLC_MAILBOX_SIZE> *sender_mailbox_ptr;
 Mail<msg_t, HDLC_MAILBOX_SIZE> hdlc_mailbox;
 Semaphore recv_buf_mutex(1);
-Semaphore recv_buf_cpy_mutex(1); 
-// Mutex recv_buf_mutex;
+Semaphore recv_pkt_mutex(1); 
 Timer global_time;
 Timer uart_lock_time;
 
-
 CircularBuffer<char, UART_BUFSIZE> circ_buf;
 
-void write_hdlc(uint8_t *,int);
+/* internally used */
+typedef struct {
+    yahdlc_control_t control;
+    char *data;
+    unsigned int length;
+} hdlc_buf_t;
 
-static char hdlc_recv_data[HDLC_MAX_PKT_SIZE];
-static char hdlc_recv_data_cpy[HDLC_MAX_PKT_SIZE];
+static char hdlc_recv_data[HDLC_MAX_PKT_SIZE]; 
+static char hdlc_recv_pkt[HDLC_MAX_PKT_SIZE];
 
-static char hdlc_send_frame[2 * (HDLC_MAX_PKT_SIZE + 2 + 2 + 2)];
+static char hdlc_send_frame[2 * (HDLC_MAX_PKT_SIZE + 2 + 2 + 2)]; //enough space fo escape chars, header, fcs
 static char hdlc_ack_frame[2 + 2 + 2 + 2];
 
 static hdlc_buf_t recv_buf = { 
     .control = {YAHDLC_FRAME_DATA, 0}, 
     .data = hdlc_recv_data, 
-    .length = 0
-};
-
-static hdlc_buf_t recv_buf_cpy = {
-    .control = {YAHDLC_FRAME_DATA, 0}, 
-    .data = hdlc_recv_data_cpy, 
     .length = 0
 };
 
@@ -114,6 +111,11 @@ static hdlc_buf_t send_buf = {
 static hdlc_buf_t ack_buf = {
     .control = {YAHDLC_FRAME_DATA, 0}, 
     .data = hdlc_ack_frame, 
+    .length = 0
+};
+
+static hdlc_pkt_t recv_pkt = {
+    .data = hdlc_recv_pkt,
     .length = 0
 };
 
@@ -144,6 +146,18 @@ static void rx_cb(void)//(void *arg, uint8_t data)
         }
     }
 
+}
+
+static void _write_hdlc(uint8_t *ptr,int len)
+{
+    int count = 0;
+
+    while ( count < len ) {
+        if (uart2.writeable()) {
+            uart2.putc(ptr[count]);   
+            count++;
+        }
+    }
 }
 
 static void _hdlc_receive(unsigned int *recv_seq_no, unsigned int *send_seq_no)
@@ -197,10 +211,11 @@ static void _hdlc_receive(unsigned int *recv_seq_no, unsigned int *send_seq_no)
                 /* lock pkt until dispatcher makes a copy and unlocks */
                 PRINTF("hdlc: received data frame w/ seq_no: %d\n", recv_buf.control.seq_no);
 
-                recv_buf_cpy_mutex.wait();
+                recv_pkt_mutex.wait();
 
                 recv_buf_mutex.wait();
-                buffer_cpy(&recv_buf_cpy,&recv_buf);
+                memcpy(recv_pkt.data, recv_buf.data, recv_buf.length);
+                recv_pkt.length = recv_buf.length;
                 recv_buf_mutex.release();
 
                 PRINTF("hdlc: got and expected seq_no %d\n", *recv_seq_no);
@@ -209,7 +224,7 @@ static void _hdlc_receive(unsigned int *recv_seq_no, unsigned int *send_seq_no)
                     return;
                 msg->sender_pid = osThreadGetId();
                 msg->type = HDLC_PKT_RDY;
-                msg->content.ptr = &recv_buf_cpy;
+                msg->content.ptr = &recv_pkt;
                 msg->source_mailbox = &hdlc_mailbox;
                 (*recv_seq_no)++;
                 PRINTF("hdlc: Thread seq_no %d: thr %d\n", 
@@ -321,7 +336,7 @@ static void _hdlc()
                         else {
                             reply->type = HDLC_RESP_RETRY_W_TIMEO;
                             reply->content.value = (uint32_t) RTRY_TIMEO_USEC;
-                            reply->sender_pid=osThreadGetId();
+                            reply->sender_pid = osThreadGetId();
                             ((Mail<msg_t, HDLC_MAILBOX_SIZE>*)msg->source_mailbox)->put(reply);
                         }
                     } else {
@@ -338,7 +353,7 @@ static void _hdlc()
                         PRINTF("hdlc: sending frame seq no %d, len %d\n", 
                             send_buf.control.seq_no,send_buf.length);
 
-                        write_hdlc((uint8_t *)send_buf.data, send_buf.length);
+                        _write_hdlc((uint8_t *)send_buf.data, send_buf.length);
                         global_time.reset();
                         uart_lock_time.reset();
                     }  
@@ -352,14 +367,14 @@ static void _hdlc()
                         &(ack_buf.length));    
                     PRINTF("hdlc: sending ack w/ seq no %d, len %d\n", 
                         ack_buf.control.seq_no,ack_buf.length);
-                    write_hdlc((uint8_t *)ack_buf.data, ack_buf.length);
+                    _write_hdlc((uint8_t *)ack_buf.data, ack_buf.length);
                     // uart2.write((uint8_t *)ack_buf.data, ack_buf.length,0,0);   
                     hdlc_mailbox.free(msg);
                     break;
                 case HDLC_MSG_RESEND:
                     PRINTF("hdlc: Resending frame w/ seq no %d (on send_seq_no %d)\n", 
                         send_buf.control.seq_no, send_seq_no);
-                    write_hdlc((uint8_t *)send_buf.data, send_buf.length);
+                    _write_hdlc((uint8_t *)send_buf.data, send_buf.length);
                     // uart2.write((uint8_t *)send_buf.data, send_buf.length,0,0);
                     global_time.reset();
                     hdlc_mailbox.free(msg); 
@@ -385,47 +400,108 @@ static void _hdlc()
     /* this should never be reached */
 }
 
-int hdlc_pkt_release(hdlc_buf_t *buf) 
-{
-    if(recv_buf_cpy_mutex.wait(0))
-    {
-        PRINTF("hdlc: Packet not locked. Might be empty!\n");
-        recv_buf_cpy_mutex.release();
-        return -1;
-    }
-    else
-    {
-        buf->control.frame = (yahdlc_frame_t)0;
-        buf->control.seq_no = 0;
-        PRINTF("hdlc: relesed lock!\n");
-
-        recv_buf_cpy_mutex.release();
-        return 0;
-    }
-
-}
-
 Mail<msg_t, HDLC_MAILBOX_SIZE> *get_hdlc_mailbox()
 {
     return &hdlc_mailbox;
 }
 
-void write_hdlc(uint8_t *ptr,int len)
+/**
+ * @brief Send @p pkt as an hdlc packet over serial. This function blocks.
+ * @param  pkt            Packet to be sent.
+ * @param  sender_mailbox Pointer to sender's mailbox.
+ * @return                [description]
+ */
+int hdlc_send_pkt(hdlc_pkt_t *pkt, Mail<msg_t, HDLC_MAILBOX_SIZE> *sender_mailbox)
 {
-    int count = 0;
+/* TODO: should the second input not be a void pointer? */
+/* TODO: limit the number of retries */
+    msg_t *msg, *msg2;
 
-    while ( count < len ) {
-        if (uart2.writeable()) {
-            uart2.putc(ptr[count]);   
-            count++;
-        }
+    /* send pkt */
+    msg = hdlc_mailbox.alloc();
+    msg->type = HDLC_MSG_SND;
+    msg->content.ptr = pkt;
+    msg->sender_pid = osThreadGetId();
+    msg->source_mailbox = sender_mailbox;
+    hdlc_mailbox.put(msg);
+
+    while(1)
+    {
+        osEvent evt = sender_mailbox->get();
+
+        if (evt.status == osEventMail) 
+        {
+            msg = (msg_t*)evt.value.p;
+
+            switch (msg->type)
+            {
+                case HDLC_RESP_SND_SUCC:
+                    PRINTF("sent frame_no %d!\n", frame_no);
+                    sender_mailbox->free(msg);
+                    return 0;
+                    break;
+                case HDLC_RESP_RETRY_W_TIMEO:
+                    Thread::wait(msg->content.value/1000);
+                    msg2 = hdlc_mailbox.alloc();
+                    if (msg2 == NULL) {
+                        while(msg2 == NULL)
+                        {
+                            msg2 = sender_mailbox->alloc();  
+                            Thread::wait(10);
+                        }
+                        /* TODO: this doesn't seem right... */
+                        msg2->type = HDLC_RESP_RETRY_W_TIMEO;
+                        msg2->content.value = (uint32_t) RTRY_TIMEO_USEC;
+                        msg2->sender_pid = osThreadGetId();
+                        msg2->source_mailbox = sender_mailbox;
+                        sender_mailbox->put(msg2);
+                        sender_mailbox->free(msg);
+                        break;
+                    }
+                    msg2->type = HDLC_MSG_SND;
+                    msg2->content.ptr = pkt;
+                    msg2->sender_pid = osThreadGetId();
+                    msg2->source_mailbox = sender_mailbox;
+                    hdlc_mailbox.put(msg2);
+                    sender_mailbox->free(msg);
+                    break;
+                default:
+                    sender_mailbox->free(msg);
+                    /* error */
+                    break;
+            }
+        }    
     }
 }
-void buffer_cpy(hdlc_buf_t* dst, hdlc_buf_t* src)
+
+/**
+ * @brief   Release packet from hdlc. 
+ * @details This should be generally thread safe because
+ *          there is only one packet at a time that the dispatcher will pass to
+ *          a destination thread based on our hdlc implementation. Only when 
+ *          that target thread releases the packet can another hdlc packet be 
+ *          received and forwarded to some target thread. Of course, if the 
+ *          dispatcher doesn't find a destination thread, it will release the 
+ *          packet accordingly.
+ *
+dr
+ * @param   buf [description]
+ * @return      [description]
+ */
+int hdlc_pkt_release(hdlc_pkt_t *pkt) 
 {
-    memcpy(dst->data,src->data,HDLC_MAX_PKT_SIZE);
-    memcpy(&dst->control,&src->control,sizeof(yahdlc_control_t));
-    dst->length=src->length;
+    /* TODO: while this function works, it has no way of associating the packet
+    with the mutex. This is bad practice, and a fix is eventually needed. */
+    if(recv_pkt_mutex.wait(0)) {
+        PRINTF("hdlc: Packet not locked. Might be empty!\n");
+        recv_pkt_mutex.release();
+        return -1;
+    } else {
+        PRINTF("hdlc: released lock!\n");
+        recv_pkt_mutex.release();
+        return 0;
+    }
+
 }
 
 Mail<msg_t, HDLC_MAILBOX_SIZE> *hdlc_init(osPriority priority) 
@@ -438,7 +514,6 @@ Mail<msg_t, HDLC_MAILBOX_SIZE> *hdlc_init(osPriority priority)
     hdlc.start(_hdlc);
     PRINTF("hdlc: thread  id %d\n",hdlc.gettid());
     LPC_UART2->IER = 0; //Disable The Interrupt
-
 
     return &hdlc_mailbox;
 }

--- a/hdlc.h
+++ b/hdlc.h
@@ -62,12 +62,6 @@
 #define HDLC_MAILBOX_SIZE       80
 
 typedef struct {
-    yahdlc_control_t control;
-    char *data;
-    unsigned int length;
-} hdlc_buf_t;
-
-typedef struct {
     osThreadId sender_pid;    
     void *source_mailbox;
     uint16_t type;              /**< Type field. */
@@ -95,9 +89,9 @@ enum {
     HDLC_PKT_RDY
 };
 
-int hdlc_pkt_release(hdlc_buf_t *buf);
+int hdlc_send_pkt(hdlc_pkt_t *pkt, Mail<msg_t, HDLC_MAILBOX_SIZE> *sender_mailbox);
+int hdlc_pkt_release(hdlc_pkt_t *pkt);
 Mail<msg_t, HDLC_MAILBOX_SIZE> *hdlc_init(osPriority priority);
 Mail<msg_t, HDLC_MAILBOX_SIZE> *get_hdlc_mailbox();
-void buffer_cpy(hdlc_buf_t* dst, hdlc_buf_t* src);
 
 #endif /* HDLC_H_ */

--- a/main.cpp
+++ b/main.cpp
@@ -71,21 +71,16 @@ DigitalOut myled(LED1);
 Mail<msg_t, HDLC_MAILBOX_SIZE> thread1_mailbox;
 Mail<msg_t, HDLC_MAILBOX_SIZE> main_thr_mailbox;
 
-
 void _thread1()
 {
 /* Initial Direction of the Antenna*/
 
     char thread1_frame_no = 0;
-    msg_t *msg, *msg2;
+    msg_t *msg;
     char send_data[HDLC_MAX_PKT_SIZE];
     char recv_data[HDLC_MAX_PKT_SIZE];
-    hdlc_pkt_t *pkt= new hdlc_pkt_t;
-    pkt->data = send_data;
-    pkt->length = 0;
-    hdlc_buf_t *buf;
-    Mail<msg_t, HDLC_MAILBOX_SIZE> *hdlc_mailbox_ptr;
-    hdlc_mailbox_ptr=get_hdlc_mailbox();
+    hdlc_pkt_t pkt = { .data = send_data, .length = 0 };
+    hdlc_pkt_t *recv_pkt;
     int exit = 0;
     static int port_no=register_thread(&thread1_mailbox);
 
@@ -95,21 +90,16 @@ void _thread1()
     {
 
         myled3=!myled3;
-        pkt->data[0] = thread1_frame_no;
-        pkt->data[1] = port_no;
+        pkt.data[0] = thread1_frame_no;
+        pkt.data[1] = port_no;
         for(int i = 2; i < HDLC_MAX_PKT_SIZE; i++) {
-            pkt->data[i] = (char) ( rand() % 0x7E);
+            pkt.data[i] = (char) ( rand() % 0x7E);
         }
 
-        pkt->length = HDLC_MAX_PKT_SIZE;
+        pkt.length = HDLC_MAX_PKT_SIZE;
 
         /* send pkt */
-        msg = hdlc_mailbox_ptr->alloc();
-        msg->type = HDLC_MSG_SND;
-        msg->content.ptr = pkt;
-        msg->sender_pid = osThreadGetId();
-        msg->source_mailbox = &thread1_mailbox;
-        hdlc_mailbox_ptr->put(msg);
+        hdlc_send_pkt(&pkt, &thread1_mailbox);
         PRINTF("thread1: sending pkt no %d \n", thread1_frame_no);
 
         while(1)
@@ -120,42 +110,11 @@ void _thread1()
                 msg = (msg_t*)evt.value.p;
                 switch (msg->type)
                 {
-                    case HDLC_RESP_SND_SUCC:
-                        PRINTF("thread1: sent frame_no %d!\n", thread1_frame_no);
-                        exit = 1;
-                        thread1_mailbox.free(msg);
-                        break;    
-                    case HDLC_RESP_RETRY_W_TIMEO:
-                        Thread::wait(msg->content.value/1000);
-                        PRINTF("main_thr: retry frame_no %d \n", thread1_frame_no);
-                        msg2 = hdlc_mailbox_ptr->alloc();
-                        if (msg2 == NULL) {
-                            Thread::wait(50);
-                            while(msg2==NULL)
-                            {
-                                msg2 = thread1_mailbox.alloc();  
-                                Thread::wait(10);
-                            }
-                            msg2->type = HDLC_RESP_RETRY_W_TIMEO;
-                            msg2->content.value = (uint32_t) RTRY_TIMEO_USEC;
-                            msg2->sender_pid = osThreadGetId();
-                            msg2->source_mailbox = &thread1_mailbox;
-                            thread1_mailbox.put(msg2);
-                            thread1_mailbox.free(msg);
-                            break;
-                        }
-                        msg2->type = HDLC_MSG_SND;
-                        msg2->content.ptr = pkt;
-                        msg2->sender_pid = osThreadGetId();
-                        msg2->source_mailbox = &thread1_mailbox;
-                        hdlc_mailbox_ptr->put(msg2);
-                        thread1_mailbox.free(msg);
-                        break;
                     case HDLC_PKT_RDY:
-                        buf = (hdlc_buf_t *)msg->content.ptr;   
-                        memcpy(recv_data, buf->data, buf->length);
+                        recv_pkt = (hdlc_pkt_t *)msg->content.ptr;   
+                        memcpy(recv_data, recv_pkt->data, recv_pkt->length);
                         thread1_mailbox.free(msg);
-                        hdlc_pkt_release(buf);
+                        hdlc_pkt_release(recv_pkt);
                         PRINTF("thread1: received pkt %d; thr %d\n", recv_data[0], recv_data[1]);
                         break;
                     default:
@@ -173,31 +132,24 @@ void _thread1()
 
         thread1_frame_no++;
         Thread::wait(500);
-
     }
 }
-
 
 int main(void)
 {
     myled=1;
-    Mail<msg_t, HDLC_MAILBOX_SIZE> *hdlc_mailbox_ptr;
-    Mail<msg_t, HDLC_MAILBOX_SIZE> *dispatch_mailbox_ptr;
     // PRINTF("In main");
-    hdlc_mailbox_ptr = hdlc_init(osPriorityRealtime);
    
-    dispatch_mailbox_ptr=dispacher_init();
+    dispacher_init();
 
-    msg_t *msg, *msg2;
+    msg_t *msg;
     char frame_no = 0;
     char send_data[HDLC_MAX_PKT_SIZE];
     char recv_data[HDLC_MAX_PKT_SIZE];
-    hdlc_pkt_t *pkt= new hdlc_pkt_t;
-    pkt->data = send_data;
-    pkt->length = 0;
-    hdlc_buf_t *buf;
+    hdlc_pkt_t pkt = { .data = send_data, .length = 0 };
+    hdlc_pkt_t *recv_pkt;
     PRINTF("In main\n");
-    static int port_no=register_thread(&main_thr_mailbox);
+    static int port_no = register_thread(&main_thr_mailbox);
     // PT
     // Thread thread1(_thread1);
     PRINTF("main_thread: port no %d \n", port_no);
@@ -213,23 +165,18 @@ int main(void)
         // PRINTF("In main\n");
 
         myled=!myled;
-        pkt->data[0] = frame_no;
-        // pkt->data[1] = frame_no;
-        pkt->data[1] = port_no;
+        pkt.data[0] = frame_no;
+        // pkt.data[1] = frame_no;
+        pkt.data[1] = port_no;
 
         for(int i = 2; i < HDLC_MAX_PKT_SIZE; i++) {
-            pkt->data[i] = (char) ( rand() % 0x7E);
+            pkt.data[i] = (char) ( rand() % 0x7E);
         }
 
-        pkt->length = HDLC_MAX_PKT_SIZE;
+        pkt.length = HDLC_MAX_PKT_SIZE;
 
         /* send pkt */
-        msg = hdlc_mailbox_ptr->alloc();
-        msg->type = HDLC_MSG_SND;
-        msg->content.ptr = pkt;
-        msg->sender_pid = osThreadGetId();
-        msg->source_mailbox = &main_thr_mailbox;
-        hdlc_mailbox_ptr->put(msg);
+        hdlc_send_pkt(&pkt, &main_thr_mailbox);
 
         PRINTF("main_thread: sending pkt no %d \n", frame_no);
 
@@ -240,46 +187,15 @@ int main(void)
 
             if (evt.status == osEventMail) 
             {
-mail_check:      msg = (msg_t*)evt.value.p;
+mail_check:     msg = (msg_t*)evt.value.p;
 
                 switch (msg->type)
                 {
-                    case HDLC_RESP_SND_SUCC:
-                        PRINTF("main_thr: sent frame_no %d!\n", frame_no);
-                        exit = 1;
-                        main_thr_mailbox.free(msg);
-                        break;
-                    case HDLC_RESP_RETRY_W_TIMEO:
-                        Thread::wait(msg->content.value/1000);
-                        PRINTF("main_thr: retry frame_no %d \n", frame_no);
-                        msg2 = hdlc_mailbox_ptr->alloc();
-                        if (msg2 == NULL) {
-                            // Thread::wait(50);
-                            while(msg2==NULL)
-                            {
-                                msg2 = main_thr_mailbox.alloc();  
-                                Thread::wait(10);
-                            }
-                            msg2->type = HDLC_RESP_RETRY_W_TIMEO;
-                            msg2->content.value = (uint32_t) RTRY_TIMEO_USEC;
-                            msg2->sender_pid = osThreadGetId();
-                            msg2->source_mailbox = &main_thr_mailbox;
-                            main_thr_mailbox.put(msg2);
-                            main_thr_mailbox.free(msg);
-                            break;
-                        }
-                        msg2->type = HDLC_MSG_SND;
-                        msg2->content.ptr = pkt;
-                        msg2->sender_pid = osThreadGetId();
-                        msg2->source_mailbox = &main_thr_mailbox;
-                        hdlc_mailbox_ptr->put(msg2);
-                        main_thr_mailbox.free(msg);
-                        break;
                     case HDLC_PKT_RDY:
-                        buf = (hdlc_buf_t *)msg->content.ptr;   
-                        memcpy(recv_data, buf->data, buf->length);
+                        recv_pkt = (hdlc_pkt_t *)msg->content.ptr;   
+                        memcpy(recv_data, recv_pkt->data, recv_pkt->length);
                         main_thr_mailbox.free(msg);
-                        hdlc_pkt_release(buf);
+                        hdlc_pkt_release(recv_pkt);
                         printf("main_thr: received pkt %d ; thr %d\n", recv_data[0], recv_data[1]);
                         break;
                     default:
@@ -302,9 +218,7 @@ mail_check:      msg = (msg_t*)evt.value.p;
 
         frame_no++;
         Thread::wait(360);
-
     }
-    PRINTF("Reached Exit");
     /* should be never reached */
-    return 0;
+    PRINTF("Reached Exit");
 }


### PR DESCRIPTION
I packaged the long sending code into one reusable function. This should reduce the code space by a lot. I also made hdlc_buf_t a "private" data type only internally used by hdlc. The dispatcher and any other threads now only see hdlc_pkt_t so we don't pass around yahdlc control data unnecessarily. I also made some code styling fixes. Please take a look at the diff to double check my work before you merge. Definitely merge this before continuing to work.