### PR TITLE
hdlc: make hdlc_buf_t private to hdlc and switch to hdlc_pkt_t for al…

### DIFF
--- a/dispatcher.cpp
+++ b/dispatcher.cpp
@@ -74,9 +74,8 @@ Thread dispatcher(osPriorityNormal,
     (uint32_t) DEFAULT_STACK_SIZE, (unsigned char *)DISPACHER_STACK); 
 
 static std::map <char, Mail<msg_t, HDLC_MAILBOX_SIZE>*> mailbox_list;
-static int registered_thr_cnt=0;
 Mutex thread_cnt_mtx;
-static int thread_cnt=0;
+static int thread_cnt = 0;
 
 int register_thread(Mail<msg_t, HDLC_MAILBOX_SIZE> *arg)
 {
@@ -96,11 +95,9 @@ void _dispatcher(void)
 
     hdlc_mailbox_ptr = get_hdlc_mailbox();
     msg_t *msg, *msg2;
-    char frame_no = 0;
-    char send_data[HDLC_MAX_PKT_SIZE];
     char recv_data[HDLC_MAX_PKT_SIZE];
 
-    hdlc_buf_t *buf;
+    hdlc_pkt_t *pkt;
     PRINTF("In dispatcher");
 
     msg = hdlc_mailbox_ptr->alloc();
@@ -133,8 +130,8 @@ void _dispatcher(void)
             switch (msg->type)
             {
                 case HDLC_PKT_RDY:
-                    buf = (hdlc_buf_t *)msg->content.ptr;   
-                    memcpy(recv_data, buf->data, buf->length);
+                    pkt = (hdlc_pkt_t *)msg->content.ptr;   
+                    memcpy(recv_data, pkt->data, pkt->length);
                     // PRINTF("dispatcher: received pkt %d; thread %d\n", recv_data[0],recv_data[1]);
 
                     if(recv_data[1]>0)
@@ -158,7 +155,7 @@ void _dispatcher(void)
                         PRINTF("dispatcher1: received pkt %d; thread %d\n", recv_data[0],recv_data[1]);
 
                         dispatcher_mailbox.free(msg);
-                        hdlc_pkt_release(buf);
+                        hdlc_pkt_release(pkt);
                     }
                     break;
                 default:

--- a/hdlc.h
+++ b/hdlc.h
@@ -62,12 +62,6 @@
 #define HDLC_MAILBOX_SIZE       80
 
 typedef struct {
-    yahdlc_control_t control;
-    char *data;
-    unsigned int length;
-} hdlc_buf_t;
-
-typedef struct {
     osThreadId sender_pid;    
     void *source_mailbox;
     uint16_t type;              /**< Type field. */
@@ -95,9 +89,8 @@ enum {
     HDLC_PKT_RDY
 };
 
-int hdlc_pkt_release(hdlc_buf_t *buf);
+int hdlc_pkt_release(hdlc_pkt_t *pkt);
 Mail<msg_t, HDLC_MAILBOX_SIZE> *hdlc_init(osPriority priority);
 Mail<msg_t, HDLC_MAILBOX_SIZE> *get_hdlc_mailbox();
-void buffer_cpy(hdlc_buf_t* dst, hdlc_buf_t* src);
 
 #endif /* HDLC_H_ */


### PR DESCRIPTION
hdlc_buf_t was always intended to be private because of the yahdlc control data. This PR removes the use of hdlc_buf_t outside of the hdlc code and makes all threads use the hdlc_pkt_t data type. I also added some code cleanup. 